### PR TITLE
[DON'T MERGE] Supports Argobots

### DIFF
--- a/config/opal_config_argobots.m4
+++ b/config/opal_config_argobots.m4
@@ -24,12 +24,14 @@ dnl
 dnl Configure Argobots threads, setting the following variables (but
 dnl  not calling AC_SUBST on them).
 
-#********************************************************************
-#
-# TODO: work in progress
-#
-#********************************************************************
 AC_DEFUN([OPAL_CONFIG_ARGOBOTS_THREADS],[
-    AC_REQUIRE([AC_PROG_GREP])
-    [$2]
+    AC_CHECK_HEADERS([abt.h],
+                     [AC_CHECK_LIB([abt],[ABT_init],
+                                    [threads_argobots_happy="yes"],
+                                    [threads_argobots_happy="no"])],
+                     [threads_argobots_happy="no"])
+
+    AS_IF([test "$threads_argobots_happy" = "yes"],
+          [$1],
+          [$2])
 ])dnl

--- a/config/opal_config_argobots.m4
+++ b/config/opal_config_argobots.m4
@@ -19,9 +19,9 @@ dnl Additional copyrights may follow
 dnl
 dnl $HEADER$
 dnl
-dnl OPAL_CONFIG_ARGOBOT_THREADS()
+dnl OPAL_CONFIG_ARGOBOTS_THREADS()
 dnl
-dnl Configure argobot threads, setting the following variables (but
+dnl Configure Argobots threads, setting the following variables (but
 dnl  not calling AC_SUBST on them).
 
 #********************************************************************
@@ -29,7 +29,7 @@ dnl  not calling AC_SUBST on them).
 # TODO: work in progress
 #
 #********************************************************************
-AC_DEFUN([OPAL_CONFIG_ARGOBOT_THREADS],[
+AC_DEFUN([OPAL_CONFIG_ARGOBOTS_THREADS],[
     AC_REQUIRE([AC_PROG_GREP])
     [$2]
 ])dnl

--- a/config/opal_config_threads.m4
+++ b/config/opal_config_threads.m4
@@ -63,8 +63,8 @@ AS_IF([test -z "$with_threads" || test "$with_threads" = "pthreads" || test "$wi
 #
 # see if argobots is called for
 #
-AS_IF([test -z "$thread_type_found" && test "$with_threads" = argobots"],
-      [OPAL_CONFIG_ARGOBOT_THREADS(HAVE_THREAD_PKG=1, HAVE_THREAD_PKG=0)
+AS_IF([test -z "$thread_type_found" && test "$with_threads" = "argobots"],
+      [OPAL_CONFIG_ARGOBOTS_THREADS(HAVE_THREAD_PKG=1, HAVE_THREAD_PKG=0)
        AC_MSG_CHECKING([for working ARGOBOTS threads package])
        AS_IF([test "$HAVE_THREAD_PKG" = "1"],
              [AC_MSG_RESULT([yes])
@@ -72,7 +72,7 @@ AS_IF([test -z "$thread_type_found" && test "$with_threads" = argobots"],
              [AC_MSG_RESULT([no])])],
       [])
 
-AS_IF([test -z "$thread_type_found" && test "$with_threads" = qthreads"],
+AS_IF([test -z "$thread_type_found" && test "$with_threads" = "qthreads"],
       [OPAL_CONFIG_QTHREADS(HAVE_THREAD_PKG=1, HAVE_THREAD_PKG=0)
        AC_MSG_CHECKING([for working Qthreads package])
        AS_IF([test "$HAVE_THREAD_PKG" = "1"],

--- a/opal/mca/event/libevent2022/libevent/poll.c
+++ b/opal/mca/event/libevent2022/libevent/poll.c
@@ -162,6 +162,9 @@ poll_dispatch(struct event_base *base, struct timeval *tv)
 
 	EVBASE_RELEASE_LOCK(base, th_base_lock);
 
+	if (msec > 0) {
+		msec = 0;
+	}
 	res = poll(event_set, nfds, msec);
 
 	EVBASE_ACQUIRE_LOCK(base, th_base_lock);

--- a/opal/mca/threads/argobots/Makefile.am
+++ b/opal/mca/threads/argobots/Makefile.am
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_LTLIBRARIES = libmca_threads_argobots.la
+
+libmca_threads_argobots_la_SOURCES = \
+    threads_argobots.h \
+    threads_argobots_component.c \
+    threads_argobots_condition.c \
+    threads_argobots_event.c \
+    threads_argobots_module.c \
+    threads_argobots_mutex.c \
+    threads_argobots_mutex.h \
+    threads_argobots_threads.h \
+    threads_argobots_tsd.h \
+    threads_argobots_wait_sync.c \
+    threads_argobots_wait_sync.h

--- a/opal/mca/threads/argobots/configure.m4
+++ b/opal/mca/threads/argobots/configure.m4
@@ -1,0 +1,62 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2019      Triad National Security, LLC. All rights
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+AC_DEFUN([MCA_opal_threads_argobots_PRIORITY], [30])
+
+AC_DEFUN([MCA_opal_threads_argobots_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+AC_DEFUN([MCA_opal_threads_argobots_POST_CONFIG],[
+    AS_IF([test "$1" = "1"], [threads_base_include="argobots/threads_argobots_threads.h"])
+])dnl
+
+AC_DEFUN([MCA_opal_mutex_argobots_POST_CONFIG],[
+    AS_IF([test "$1" = "1"], [mutex_base_include="argobots/threads_argobots_mutex.h"])
+    AC_MSG_CHECKING([mutex_base_include = $mutex_base_include])
+])dnl
+
+AC_DEFUN([MCA_opal_tsd_argobots_POST_CONFIG],[
+    AS_IF([test "$1" = "1"], [threads_base_include="argobots/threads_argobots_tsd.h"])
+    AC_MSG_CHECKING([threads_base_include = $threads_base_include])
+])dnl
+
+AC_DEFUN([MCA_opal_wait_sync_argobots_POST_CONFIG],[
+    AS_IF([test "$1" = "1"], [wait_sync_base_include="argobots/threads_argobots_wait_sync.h"])
+    AC_MSG_CHECKING([wait_sync_base_include = $wait_sync_base_include])
+])dnl
+
+# MCA_threads_argobots_CONFIG(action-if-can-compile,
+#                        [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_opal_threads_argobots_CONFIG],[
+    AC_CONFIG_FILES([opal/mca/threads/argobots/Makefile])
+
+    AC_MSG_CHECKING([HAVE_THREAD_PKG_TYPE = $HAVE_THREAD_PKG_TYPE])
+
+    AS_IF([test "$HAVE_THREAD_PKG_TYPE" = "argobots"],
+          [$1],
+          [$2])
+])

--- a/opal/mca/threads/argobots/owner.txt
+++ b/opal/mca/threads/argobots/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: SNL
+status: unmaintained

--- a/opal/mca/threads/argobots/threads_argobots.h
+++ b/opal/mca/threads/argobots/threads_argobots.h
@@ -1,0 +1,12 @@
+
+#ifndef  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_H
+#define  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_H 1
+
+#include <abt.h>
+
+static inline void ensure_init_argobots(void) {
+	if (ABT_initialized() != 0)
+		ABT_init(0, 0);
+}
+
+#endif /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_H */

--- a/opal/mca/threads/argobots/threads_argobots_component.c
+++ b/opal/mca/threads/argobots/threads_argobots_component.c
@@ -1,0 +1,57 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2014 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal/mca/threads/thread.h"
+#include "opal/mca/threads/threads.h"
+#include "opal/constants.h"
+#include <abt.h>
+
+static int opal_threads_argobots_open(void);
+
+const opal_threads_base_component_2_0_0_t mca_threads_argobots_component = {
+    /* First, the mca_component_t struct containing meta information
+       about the component itself */
+    .threadsc_version = {
+        OPAL_THREADS_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .mca_component_name = "argobots",
+        MCA_BASE_MAKE_VERSION(component, OPAL_MAJOR_VERSION, OPAL_MINOR_VERSION,
+                              OPAL_RELEASE_VERSION),
+
+        .mca_open_component = opal_threads_argobots_open,
+    },
+    .threadsc_data = {
+        /* The component is checkpoint ready */
+        MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+};
+
+int opal_threads_argobots_open(void)
+{
+    ensure_init_argobots();
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/threads/argobots/threads_argobots_condition.c
+++ b/opal/mca/threads/argobots/threads_argobots_condition.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal_config.h"
+
+#include "opal/mca/threads/condition.h"
+
+
+static void opal_condition_construct(opal_condition_t *c)
+{
+    c->c_waiting = 0;
+    c->c_signaled = 0;
+}
+
+
+static void opal_condition_destruct(opal_condition_t *c)
+{
+}
+
+OBJ_CLASS_INSTANCE(opal_condition_t,
+                   opal_object_t,
+                   opal_condition_construct,
+                   opal_condition_destruct);

--- a/opal/mca/threads/argobots/threads_argobots_event.c
+++ b/opal/mca/threads/argobots/threads_argobots_event.c
@@ -1,0 +1,136 @@
+
+#include "opal/mca/threads/threads.h"
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal/mca/event/libevent2022/libevent/include/event2/thread.h"
+#include "opal/mca/event/libevent2022/libevent/include/event2/event-config.h"
+#include "opal/mca/event/libevent2022/libevent/include/event2/util.h"
+
+#include <abt.h>
+
+static void *
+evthread_argobots_lock_alloc(unsigned locktype)
+{
+    ABT_mutex lock;
+	if (locktype & EVTHREAD_LOCKTYPE_RECURSIVE) {
+        ABT_mutex_attr abt_mutex_attr;
+        ABT_mutex_attr_create(&abt_mutex_attr);
+        ABT_mutex_attr_set_recursive(abt_mutex_attr, ABT_TRUE);
+        ABT_mutex_create_with_attr(abt_mutex_attr, &lock);
+        ABT_mutex_attr_free(&abt_mutex_attr);
+    } else {
+        ABT_mutex_create(&lock);
+    }
+	return lock;
+}
+
+static void
+evthread_argobots_lock_free(void *_lock, unsigned locktype)
+{
+	ABT_mutex lock = _lock;
+	ABT_mutex_free(&lock);
+}
+
+static int
+evthread_argobots_lock(unsigned mode, void *_lock)
+{
+	int ret;
+	ABT_mutex lock = _lock;
+	if (mode & EVTHREAD_TRY) {
+		ret = ABT_mutex_trylock(lock);
+	} else {
+		ret = ABT_mutex_lock(lock);
+	}
+	return ret;
+}
+
+static int
+evthread_argobots_unlock(unsigned mode, void *_lock)
+{
+	ABT_mutex lock = _lock;
+	int ret = ABT_mutex_unlock(lock);
+	/* This yield is necessary to avoid taking a lock consecutively. */
+	ABT_thread_yield();
+	return ret;
+}
+
+static unsigned long
+evthread_argobots_get_id(void)
+{
+	ABT_thread thr;
+	ABT_thread_self(&thr);
+	return (unsigned long)((intptr_t)thr);
+}
+
+static void *
+evthread_argobots_cond_alloc(unsigned condflags)
+{
+	ABT_cond cond;
+	ABT_cond_create(&cond);
+	return cond;
+}
+
+static void
+evthread_argobots_cond_free(void *_cond)
+{
+	ABT_cond cond = _cond;
+	ABT_cond_free(&cond);
+}
+
+static int
+evthread_argobots_cond_signal(void *_cond, int broadcast)
+{
+	ABT_cond cond = _cond;
+	int r;
+	if (broadcast)
+		r = ABT_cond_broadcast(cond);
+	else
+		r = ABT_cond_signal(cond);
+	return r ? -1 : 0;
+}
+
+static int
+evthread_argobots_cond_wait(void *_cond, void *_lock, const struct timeval *tv)
+{
+	int r;
+	ABT_cond cond = _cond;
+	ABT_mutex lock = _lock;
+
+	if (tv) {
+		struct timeval now, abstime;
+		struct timespec ts;
+		evutil_gettimeofday(&now, NULL);
+		evutil_timeradd(&now, tv, &abstime);
+		ts.tv_sec = abstime.tv_sec;
+		ts.tv_nsec = abstime.tv_usec*1000;
+		r = ABT_cond_timedwait(cond, lock, &ts);
+		if (r != 0)
+			return 1;
+		else
+			return 0;
+	} else {
+		r = ABT_cond_wait(cond, lock);
+		return r ? -1 : 0;
+	}
+}
+
+void opal_event_use_threads(void) {
+	struct evthread_lock_callbacks cbs = {
+		EVTHREAD_LOCK_API_VERSION,
+		EVTHREAD_LOCKTYPE_RECURSIVE,
+		evthread_argobots_lock_alloc,
+		evthread_argobots_lock_free,
+		evthread_argobots_lock,
+		evthread_argobots_unlock
+	};
+	struct evthread_condition_callbacks cond_cbs = {
+		EVTHREAD_CONDITION_API_VERSION,
+		evthread_argobots_cond_alloc,
+		evthread_argobots_cond_free,
+		evthread_argobots_cond_signal,
+		evthread_argobots_cond_wait
+	};
+	ensure_init_argobots();
+	evthread_set_lock_callbacks(&cbs);
+	evthread_set_condition_callbacks(&cond_cbs);
+	evthread_set_id_callback(evthread_argobots_get_id);
+}

--- a/opal/mca/threads/argobots/threads_argobots_module.c
+++ b/opal/mca/threads/argobots/threads_argobots_module.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include <unistd.h>
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal/constants.h"
+#include "opal/util/sys_limits.h"
+#include "opal/util/output.h"
+#include "opal/prefetch.h"
+#include "opal/mca/threads/threads.h"
+#include "opal/mca/threads/tsd.h"
+
+#include <abt.h>
+
+struct opal_tsd_key_value {
+    opal_tsd_key_t key;
+    opal_tsd_destructor_t destructor;
+};
+
+static ABT_thread opal_main_thread;
+struct opal_tsd_key_value *opal_tsd_key_values = NULL;
+static int opal_tsd_key_values_count = 0;
+
+/*
+ * Constructor
+ */
+static void opal_thread_construct(opal_thread_t *t)
+{
+    t->t_run = 0;
+    t->t_handle = ABT_THREAD_NULL;
+}
+
+OBJ_CLASS_INSTANCE(opal_thread_t,
+                   opal_object_t,
+                   opal_thread_construct, NULL);
+
+static inline ABT_thread opal_thread_get_argobots_self(void) {
+    ABT_thread self;
+    ABT_thread_self(&self);
+    return self;
+}
+
+static void opal_thread_argobots_wrapper(void *arg) {
+    opal_thread_t *t = (opal_thread_t *) arg;
+    t->t_ret = ((void*(*)(void*)) t->t_run)(t);
+}
+
+opal_thread_t *opal_thread_get_self(void)
+{
+    ensure_init_argobots();
+    opal_thread_t *t = OBJ_NEW(opal_thread_t);
+    t->t_handle = opal_thread_get_argobots_self();
+    return t;
+}
+
+bool opal_thread_self_compare(opal_thread_t *t)
+{
+    ensure_init_argobots();
+    return t->t_handle == opal_thread_get_argobots_self();
+}
+
+int opal_thread_join(opal_thread_t *t, void **thr_return) {
+    ensure_init_argobots();
+    int rc = ABT_thread_free(&t->t_handle);
+    if (thr_return)
+        *thr_return = t->t_ret;
+    t->t_handle = ABT_THREAD_NULL;
+    return (rc == 0) ? OPAL_SUCCESS : OPAL_ERROR;
+}
+
+void opal_thread_set_main() {
+    ensure_init_argobots();
+    opal_main_thread = opal_thread_get_argobots_self();
+}
+
+int opal_thread_start(opal_thread_t *t) {
+    ensure_init_argobots();
+    int rc;
+    if (OPAL_ENABLE_DEBUG) {
+        if (NULL == t->t_run || t->t_handle != ABT_THREAD_NULL) {
+            return OPAL_ERR_BAD_PARAM;
+        }
+    }
+
+    ABT_xstream self_xstream;
+    ABT_xstream_self(&self_xstream);
+    rc = ABT_thread_create_on_xstream(self_xstream,
+                                      opal_thread_argobots_wrapper, t,
+                                      ABT_THREAD_ATTR_NULL, &t->t_handle);
+
+    return (rc == 0) ? OPAL_SUCCESS : OPAL_ERROR;
+}
+
+opal_class_t opal_thread_t_class;
+
+int opal_tsd_key_create(opal_tsd_key_t *key, opal_tsd_destructor_t destructor)
+{
+    ensure_init_argobots();
+    int rc;
+    rc = ABT_key_create(destructor, key);
+    if ((0 == rc) && (opal_thread_get_argobots_self() == opal_main_thread)) {
+        opal_tsd_key_values = (struct opal_tsd_key_value *)realloc(opal_tsd_key_values, (opal_tsd_key_values_count+1) * sizeof(struct opal_tsd_key_value));
+        opal_tsd_key_values[opal_tsd_key_values_count].key = *key;
+        opal_tsd_key_values[opal_tsd_key_values_count].destructor = destructor;
+        opal_tsd_key_values_count ++;
+    }
+    return rc;
+}
+
+int opal_tsd_keys_destruct()
+{
+    ensure_init_argobots();
+    int i;
+    void * ptr;
+    for (i=0; i<opal_tsd_key_values_count; i++) {
+        if(OPAL_SUCCESS == opal_tsd_getspecific(opal_tsd_key_values[i].key, &ptr)) {
+            if (NULL != opal_tsd_key_values[i].destructor) {
+                opal_tsd_key_values[i].destructor(ptr);
+                opal_tsd_setspecific(opal_tsd_key_values[i].key, NULL);
+            }
+        }
+    }
+    if (0 < opal_tsd_key_values_count) {
+        free(opal_tsd_key_values);
+        opal_tsd_key_values_count = 0;
+    }
+    return OPAL_SUCCESS;
+}

--- a/opal/mca/threads/argobots/threads_argobots_mutex.c
+++ b/opal/mca/threads/argobots/threads_argobots_mutex.c
@@ -1,0 +1,86 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal_config.h"
+
+#include <errno.h>
+#include <pthread.h>
+
+#include "opal/mca/threads/mutex.h"
+#include "opal/mca/threads/argobots/threads_argobots_mutex.h"
+
+/*
+ * Wait and see if some upper layer wants to use threads, if support
+ * exists.
+ */
+bool opal_uses_threads = false;
+
+static void mca_threads_argobots_mutex_constructor(opal_mutex_t *p_mutex) {
+    ensure_init_argobots();
+    p_mutex->m_lock_argobots = OPAL_ABT_MUTEX_NULL;
+    p_mutex->m_recursive = 0;
+#if OPAL_ENABLE_DEBUG
+    p_mutex->m_lock_debug = 0;
+    p_mutex->m_lock_file = NULL;
+    p_mutex->m_lock_line = 0;
+#endif
+    opal_atomic_lock_init(&p_mutex->m_lock_atomic, 0);
+}
+
+static void mca_threads_argobots_mutex_desctructor(opal_mutex_t *p_mutex) {
+    ensure_init_argobots();
+    if (p_mutex->m_lock_argobots != OPAL_ABT_MUTEX_NULL)
+        ABT_mutex_free(&p_mutex->m_lock_argobots);
+}
+
+static void mca_threads_argobots_recursive_mutex_constructor
+        (opal_recursive_mutex_t *p_mutex) {
+    ensure_init_argobots();
+    p_mutex->m_lock_argobots = OPAL_ABT_MUTEX_NULL;
+    p_mutex->m_recursive = 1;
+#if OPAL_ENABLE_DEBUG
+    p_mutex->m_lock_debug = 0;
+    p_mutex->m_lock_file = NULL;
+    p_mutex->m_lock_line = 0;
+#endif
+    opal_atomic_lock_init(&p_mutex->m_lock_atomic, 0);
+}
+
+static void mca_threads_argobots_recursive_mutex_desctructor
+        (opal_recursive_mutex_t *p_mutex) {
+    ensure_init_argobots();
+    if (p_mutex->m_lock_argobots != OPAL_ABT_MUTEX_NULL)
+        ABT_mutex_free(&p_mutex->m_lock_argobots);
+}
+
+OBJ_CLASS_INSTANCE(opal_mutex_t,
+                   opal_object_t,
+                   mca_threads_argobots_mutex_constructor,
+                   mca_threads_argobots_mutex_desctructor);
+OBJ_CLASS_INSTANCE(opal_recursive_mutex_t,
+                   opal_object_t,
+                   mca_threads_argobots_recursive_mutex_constructor,
+                   mca_threads_argobots_recursive_mutex_desctructor);

--- a/opal/mca/threads/argobots/threads_argobots_mutex.h
+++ b/opal/mca/threads/argobots/threads_argobots_mutex.h
@@ -1,0 +1,310 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+ * 
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_MUTEX_H
+#define  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_MUTEX_H 1
+
+/**
+ * @file:
+ *
+ * Mutual exclusion functions: Unix implementation.
+ *
+ * Functions for locking of critical sections.
+ *
+ * On unix, use Argobots or our own atomic operations as
+ * available.
+ */
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal_config.h"
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "opal/class/opal_object.h"
+#include "opal/sys/atomic.h"
+
+#include <abt.h>
+
+BEGIN_C_DECLS
+
+/* Don't use ABT_MUTEX_NULL, since it might be not NULL. */
+#define OPAL_ABT_MUTEX_NULL 0
+
+struct opal_mutex_t {
+    opal_object_t super;
+
+    ABT_mutex m_lock_argobots;
+    int m_recursive;
+
+#if OPAL_ENABLE_DEBUG
+    int m_lock_debug;
+    const char *m_lock_file;
+    int m_lock_line;
+#endif
+
+    opal_atomic_lock_t m_lock_atomic;
+};
+
+typedef struct opal_argobots_mutex_t opal_pthread_mutex_t;
+typedef struct opal_argobots_mutex_t opal_pthread_recursive_mutex_t;
+
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_mutex_t);
+OPAL_DECLSPEC OBJ_CLASS_DECLARATION(opal_recursive_mutex_t);
+
+#if OPAL_ENABLE_DEBUG
+#define OPAL_MUTEX_STATIC_INIT                                          \
+    {                                                                   \
+        .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
+        .m_lock_argobots = OPAL_ABT_MUTEX_NULL,                         \
+        .m_recursive = 0,                                               \
+        .m_lock_debug = 0,                                              \
+        .m_lock_file = NULL,                                            \
+        .m_lock_line = 0,                                               \
+        .m_lock_atomic = OPAL_ATOMIC_LOCK_INIT,                         \
+    }
+#else
+#define OPAL_MUTEX_STATIC_INIT                                          \
+    {                                                                   \
+        .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
+        .m_lock_argobots = OPAL_ABT_MUTEX_NULL,                         \
+        .m_recursive = 0,                                               \
+        .m_lock_atomic = OPAL_ATOMIC_LOCK_INIT,                         \
+    }
+#endif
+
+#if defined(OPAL_PTHREAD_RECURSIVE_MUTEX_INITIALIZER)
+
+#if OPAL_ENABLE_DEBUG
+#define OPAL_RECURSIVE_MUTEX_STATIC_INIT                                \
+    {                                                                   \
+        .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
+        .m_lock_argobots = OPAL_ABT_MUTEX_NULL,                         \
+        .m_recursive = 1,                                               \
+        .m_lock_debug = 0,                                              \
+        .m_lock_file = NULL,                                            \
+        .m_lock_line = 0,                                               \
+        .m_lock_atomic = OPAL_ATOMIC_LOCK_INIT,                         \
+    }
+#else
+#define OPAL_RECURSIVE_MUTEX_STATIC_INIT                                \
+    {                                                                   \
+        .super = OPAL_OBJ_STATIC_INIT(opal_mutex_t),                    \
+        .m_lock_argobots = OPAL_ABT_MUTEX_NULL,                         \
+        .m_recursive = 1,                                               \
+        .m_lock_atomic = OPAL_ATOMIC_LOCK_INIT,                         \
+    }
+#endif
+
+#endif
+
+/************************************************************************
+ *
+ * mutex operations (non-atomic versions)
+ *
+ ************************************************************************/
+
+static inline void opal_mutex_create(struct opal_mutex_t *m) {
+    while (m->m_lock_argobots == OPAL_ABT_MUTEX_NULL) {
+        ABT_mutex abt_mutex;
+        if (m->m_recursive) {
+            ABT_mutex_attr abt_mutex_attr;
+            ABT_mutex_attr_create(&abt_mutex_attr);
+            ABT_mutex_attr_set_recursive(abt_mutex_attr, ABT_TRUE);
+            ABT_mutex_create_with_attr(abt_mutex_attr, &abt_mutex);
+            ABT_mutex_attr_free(&abt_mutex_attr);
+        } else {
+            ABT_mutex_create(&abt_mutex);
+        }
+        void *null_ptr = OPAL_ABT_MUTEX_NULL;
+        if (opal_atomic_compare_exchange_strong_ptr(&m->m_lock_argobots,
+                                                    &null_ptr,
+                                                    abt_mutex)) {
+            /* mutex is successfully created and substituted. */
+            return;
+        }
+        ABT_mutex_free(&abt_mutex);
+    }
+}
+
+static inline int opal_mutex_trylock(opal_mutex_t *m)
+{
+    ensure_init_argobots();
+    if (m->m_lock_argobots == OPAL_ABT_MUTEX_NULL)
+        opal_mutex_create(m);
+#if OPAL_ENABLE_DEBUG
+    int ret = ABT_mutex_trylock(m->m_lock_argobots);
+    if (ret != 0) {
+        errno = ret;
+        perror("opal_mutex_trylock()");
+        abort();
+    }
+    return ret;
+#else
+    return ABT_mutex_trylock(m->m_lock_argobots);
+#endif
+}
+
+static inline void opal_mutex_lock(opal_mutex_t *m)
+{
+    ensure_init_argobots();
+    if (m->m_lock_argobots == OPAL_ABT_MUTEX_NULL)
+        opal_mutex_create(m);
+#if OPAL_ENABLE_DEBUG
+    int ret = ABT_mutex_lock(m->m_lock_argobots);
+    if (ret != 0) {
+        errno = ret;
+        perror("opal_mutex_lock()");
+        abort();
+    }
+#else
+    ABT_mutex_lock(m->m_lock_argobots);
+#endif
+}
+
+static inline void opal_mutex_unlock(opal_mutex_t *m)
+{
+    ensure_init_argobots();
+    if (m->m_lock_argobots == OPAL_ABT_MUTEX_NULL)
+        opal_mutex_create(m);
+#if OPAL_ENABLE_DEBUG
+    int ret = ABT_mutex_unlock(m->m_lock_argobots);
+    if (ret != 0) {
+        errno = ret;
+        perror("opal_mutex_unlock");
+        abort();
+    }
+#else
+    ABT_mutex_unlock(m->m_lock_argobots);
+#endif
+    /* For fairness of locking. */
+    ABT_thread_yield();
+}
+
+/************************************************************************
+ *
+ * mutex operations (atomic versions)
+ *
+ ************************************************************************/
+
+#if OPAL_HAVE_ATOMIC_SPINLOCKS
+
+/************************************************************************
+ * Spin Locks
+ ************************************************************************/
+
+static inline int opal_mutex_atomic_trylock(opal_mutex_t *m)
+{
+    return opal_atomic_trylock(&m->m_lock_atomic);
+}
+
+static inline void opal_mutex_atomic_lock(opal_mutex_t *m)
+{
+    opal_atomic_lock(&m->m_lock_atomic);
+}
+
+static inline void opal_mutex_atomic_unlock(opal_mutex_t *m)
+{
+    opal_atomic_unlock(&m->m_lock_atomic);
+}
+
+#else
+
+/************************************************************************
+ * Standard locking
+ ************************************************************************/
+
+static inline int opal_mutex_atomic_trylock(opal_mutex_t *m)
+{
+    return opal_mutex_trylock(m);
+}
+
+static inline void opal_mutex_atomic_lock(opal_mutex_t *m)
+{
+    opal_mutex_lock(m);
+}
+
+static inline void opal_mutex_atomic_unlock(opal_mutex_t *m)
+{
+    opal_mutex_unlock(m);
+}
+
+#endif
+
+#define OPAL_ABT_COND_NULL NULL
+typedef ABT_cond opal_cond_t;
+#define OPAL_CONDITION_STATIC_INIT OPAL_ABT_COND_NULL
+
+static inline void opal_cond_create(opal_cond_t *cond) {
+    ensure_init_argobots();
+    while (*cond == OPAL_ABT_COND_NULL) {
+        ABT_cond new_cond;
+        ABT_cond_create(&new_cond);
+        void *null_ptr = OPAL_ABT_COND_NULL;
+        if (opal_atomic_compare_exchange_strong_ptr(cond, &null_ptr,
+                                                    new_cond)) {
+            /* cond is successfully created and substituted. */
+            return;
+        }
+        ABT_cond_free(&new_cond);
+    }
+}
+
+static inline int opal_cond_init(opal_cond_t *cond) {
+    *cond = OPAL_ABT_COND_NULL;
+    return 0;
+}
+
+static inline int opal_cond_wait(opal_cond_t *cond, opal_mutex_t *lock) {
+    ensure_init_argobots();
+    if (*cond == OPAL_ABT_COND_NULL)
+        opal_cond_create(cond);
+    return ABT_cond_wait(*cond, lock->m_lock_argobots);
+}
+
+static inline int opal_cond_broadcast(opal_cond_t *cond) {
+    ensure_init_argobots();
+    if (*cond == OPAL_ABT_COND_NULL)
+        opal_cond_create(cond);
+    return ABT_cond_broadcast(*cond);
+}
+
+static inline int opal_cond_signal(opal_cond_t *cond) {
+    ensure_init_argobots();
+    if (*cond == OPAL_ABT_COND_NULL)
+        opal_cond_create(cond);
+    return ABT_cond_signal(*cond);
+}
+
+static inline int opal_cond_destroy(opal_cond_t *cond) {
+    ensure_init_argobots();
+    if (*cond != OPAL_ABT_COND_NULL)
+        ABT_cond_free(cond);
+    return 0;
+}
+
+END_C_DECLS
+
+#endif           /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_MUTEX_H */

--- a/opal/mca/threads/argobots/threads_argobots_threads.h
+++ b/opal/mca/threads/argobots/threads_argobots_threads.h
@@ -1,0 +1,16 @@
+
+#ifndef  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_THREADS_H
+#define  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_THREADS_H 1
+
+#include <abt.h>
+#include <signal.h>
+
+struct opal_thread_t {
+    opal_object_t super;
+    opal_thread_fn_t t_run;
+    void* t_arg;
+    ABT_thread t_handle;
+    void* t_ret;
+};
+
+#endif /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_THREADS_H */

--- a/opal/mca/threads/argobots/threads_argobots_tsd.h
+++ b/opal/mca/threads/argobots/threads_argobots_tsd.h
@@ -1,0 +1,32 @@
+
+#ifndef  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_TSD_H
+#define  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_TSD_H 1
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include <abt.h>
+
+typedef ABT_key opal_tsd_key_t;
+
+static inline int
+opal_tsd_key_delete(opal_tsd_key_t key)
+{
+    ensure_init_argobots();
+    return ABT_key_free(&key);
+}
+
+static inline int
+opal_tsd_setspecific(opal_tsd_key_t key, void *value)
+{
+    ensure_init_argobots();
+    return ABT_key_set(key, value);
+}
+
+static inline int
+opal_tsd_getspecific(opal_tsd_key_t key, void **valuep)
+{
+    ensure_init_argobots();
+    ABT_key_get(key, valuep);
+    return OPAL_SUCCESS;
+}
+
+#endif /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_TSD_H */

--- a/opal/mca/threads/argobots/threads_argobots_wait_sync.c
+++ b/opal/mca/threads/argobots/threads_argobots_wait_sync.c
@@ -1,0 +1,112 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2016 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2019      Sandia National Laboratories.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include "opal/mca/threads/wait_sync.h"
+
+static opal_mutex_t wait_sync_lock = OPAL_MUTEX_STATIC_INIT;
+static ompi_wait_sync_t* wait_sync_list = NULL;
+
+static opal_atomic_int32_t num_thread_in_progress = 0;
+
+#define WAIT_SYNC_PASS_OWNERSHIP(who)                  \
+    do {                                               \
+        ensure_init_argobots();                        \
+        ABT_mutex_lock((who)->lock);                   \
+        ABT_cond_signal((who)->condition );            \
+        ABT_mutex_unlock((who)->lock);                 \
+    } while(0)
+
+int ompi_sync_wait_mt(ompi_wait_sync_t *sync)
+{
+    ensure_init_argobots();
+    /* Don't stop if the waiting synchronization is completed. We avoid the
+     * race condition around the release of the synchronization using the
+     * signaling field.
+     */
+    if(sync->count <= 0)
+        return (0 == sync->status) ? OPAL_SUCCESS : OPAL_ERROR;
+
+    /* lock so nobody can signal us during the list updating */
+    ABT_mutex_lock(sync->lock);
+
+    /* Now that we hold the lock make sure another thread has not already
+     * call cond_signal.
+     */
+    if(sync->count <= 0) {
+        ABT_mutex_unlock(sync->lock);
+        return (0 == sync->status) ? OPAL_SUCCESS : OPAL_ERROR;
+    }
+
+    /* Insert sync on the list of pending synchronization constructs */
+    OPAL_THREAD_LOCK(&wait_sync_lock);
+    if( NULL == wait_sync_list ) {
+        sync->next = sync->prev = sync;
+        wait_sync_list = sync;
+    } else {
+        sync->prev = wait_sync_list->prev;
+        sync->prev->next = sync;
+        sync->next = wait_sync_list;
+        wait_sync_list->prev = sync;
+    }
+    OPAL_THREAD_UNLOCK(&wait_sync_lock);
+
+    /**
+     * If we are not responsible for progresing, go silent until something worth noticing happen:
+     *  - this thread has been promoted to take care of the progress
+     *  - our sync has been triggered.
+     */
+ check_status:
+    if( sync != wait_sync_list && num_thread_in_progress >= opal_max_thread_in_progress) {
+        ABT_cond_wait(sync->condition, sync->lock);
+
+        /**
+         * At this point either the sync was completed in which case
+         * we should remove it from the wait list, or/and I was
+         * promoted as the progress manager.
+         */
+
+        if( sync->count <= 0 ) {  /* Completed? */
+            ABT_mutex_unlock(sync->lock);
+            goto i_am_done;
+        }
+        /* either promoted, or spurious wakeup ! */
+        goto check_status;
+    }
+    ABT_mutex_unlock(sync->lock);
+
+    OPAL_THREAD_ADD_FETCH32(&num_thread_in_progress, 1);
+    while(sync->count > 0) {  /* progress till completion */
+        opal_progress();  /* don't progress with the sync lock locked or you'll deadlock */
+        ABT_thread_yield();
+    }
+    OPAL_THREAD_ADD_FETCH32(&num_thread_in_progress, -1);
+
+ i_am_done:
+    /* My sync is now complete. Trim the list: remove self, wake next */
+    OPAL_THREAD_LOCK(&wait_sync_lock);
+    sync->prev->next = sync->next;
+    sync->next->prev = sync->prev;
+    /* In case I am the progress manager, pass the duties on */
+    if( sync == wait_sync_list ) {
+        wait_sync_list = (sync == sync->next) ? NULL : sync->next;
+        if( NULL != wait_sync_list )
+            WAIT_SYNC_PASS_OWNERSHIP(wait_sync_list);
+    }
+    OPAL_THREAD_UNLOCK(&wait_sync_lock);
+
+    return (0 == sync->status) ? OPAL_SUCCESS : OPAL_ERROR;
+}

--- a/opal/mca/threads/argobots/threads_argobots_wait_sync.h
+++ b/opal/mca/threads/argobots/threads_argobots_wait_sync.h
@@ -1,0 +1,87 @@
+
+#ifndef  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_WAIT_SYNC_H
+#define  OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_WAIT_SYNC_H 1
+
+#include "opal/mca/threads/argobots/threads_argobots.h"
+#include <abt.h>
+
+typedef struct ompi_wait_sync_t {
+    opal_atomic_int32_t count;
+    int32_t status;
+    ABT_cond condition;
+    ABT_mutex lock;
+    struct ompi_wait_sync_t *next;
+    struct ompi_wait_sync_t *prev;
+    volatile bool signaling;
+} ompi_wait_sync_t;
+
+#define SYNC_WAIT(sync)                 (opal_using_threads() ? ompi_sync_wait_mt (sync) : sync_wait_st (sync))
+
+/* The loop in release handles a race condition between the signaling
+ * thread and the destruction of the condition variable. The signaling
+ * member will be set to false after the final signaling thread has
+ * finished operating on the sync object. This is done to avoid
+ * extra atomics in the signalling function and keep it as fast
+ * as possible. Note that the race window is small so spinning here
+ * is more optimal than sleeping since this macro is called in
+ * the critical path. */
+#define WAIT_SYNC_RELEASE(sync)                       \
+    if (opal_using_threads()) {                       \
+        ensure_init_argobots();                       \
+        while ((sync)->signaling) {                   \
+            ABT_thread_yield();                       \
+            continue;                                 \
+        }                                             \
+        ABT_cond_free(&(sync)->condition);            \
+        ABT_mutex_free(&(sync)->lock);                \
+    }
+
+#define WAIT_SYNC_RELEASE_NOWAIT(sync)                \
+    if (opal_using_threads()) {                       \
+        ensure_init_argobots();                       \
+        ABT_cond_free(&(sync)->condition);            \
+        ABT_mutex_free(&(sync)->lock);                \
+    }
+
+
+#define WAIT_SYNC_SIGNAL(sync)                        \
+    if (opal_using_threads()) {                       \
+        ensure_init_argobots();                       \
+        ABT_mutex_lock(sync->lock);                   \
+        ABT_cond_signal(sync->condition);             \
+        ABT_mutex_unlock(sync->lock);                 \
+        sync->signaling = false;                      \
+    }
+
+#define WAIT_SYNC_SIGNALLED(sync){                    \
+        (sync)->signaling = false;                    \
+}
+
+OPAL_DECLSPEC int ompi_sync_wait_mt(ompi_wait_sync_t *sync);
+static inline int sync_wait_st (ompi_wait_sync_t *sync)
+{
+    ensure_init_argobots();
+    while (sync->count > 0) {
+        opal_progress();
+        ABT_thread_yield();
+    }
+
+    return sync->status;
+}
+
+
+#define WAIT_SYNC_INIT(sync,c)                                  \
+    do {                                                        \
+        (sync)->count = (c);                                    \
+        (sync)->next = NULL;                                    \
+        (sync)->prev = NULL;                                    \
+        (sync)->status = 0;                                     \
+        (sync)->signaling = (0 != (c));                         \
+        if (opal_using_threads()) {                             \
+            ensure_init_argobots();                             \
+            ABT_cond_create (&(sync)->condition);               \
+            ABT_mutex_create (&(sync)->lock);                   \
+        }                                                       \
+    } while(0)
+
+#endif /* OPAL_MCA_THREADS_ARGOBOTS_THREADS_ARGOBOTS_WAIT_SYNC_H */

--- a/test/asm/Makefile.am
+++ b/test/asm/Makefile.am
@@ -43,39 +43,40 @@ atomic_barrier_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_barrier.c atomic_barrier_noinline.c
 atomic_barrier_noinline_SOURCES = atomic_barrier_noinline.c
 atomic_barrier_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
+atomic_barrier_noinline_LDADD = $(libs) -lpthread
 
 ######################################################################
 
 atomic_spinlock_SOURCES = atomic_spinlock.c
-atomic_spinlock_LDADD = $(libs)
+atomic_spinlock_LDADD = $(libs) -lpthread
 
 atomic_spinlock_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_spinlock.c atomic_spinlock_noinline.c
 atomic_spinlock_noinline_SOURCES = atomic_spinlock_noinline.c
 atomic_spinlock_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_spinlock_noinline_LDADD = $(libs)
+atomic_spinlock_noinline_LDADD = $(libs) -lpthread
 
 ######################################################################
 
 atomic_math_SOURCES = atomic_math.c
-atomic_math_LDADD = $(libs)
+atomic_math_LDADD = $(libs) -lpthread
 
 atomic_math_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_math.c atomic_math_noinline.c
 atomic_math_noinline_SOURCES = atomic_math_noinline.c
 atomic_math_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_math_noinline_LDADD = $(libs)
+atomic_math_noinline_LDADD = $(libs) -lpthread
 
 ######################################################################
 
 atomic_cmpset_SOURCES = atomic_cmpset.c
-atomic_cmpset_LDADD = $(libs)
+atomic_cmpset_LDADD = $(libs) -lpthread
 
 atomic_cmpset_noinline.c:
 	ln -s $(top_srcdir)/test/asm/atomic_cmpset.c atomic_cmpset_noinline.c
 atomic_cmpset_noinline_SOURCES = atomic_cmpset_noinline.c
 atomic_cmpset_noinline_CFLAGS = $(AM_CFLAGS) -DOMPI_DISABLE_INLINE_ASM
-atomic_cmpset_noinline_LDADD = $(libs)
+atomic_cmpset_noinline_LDADD = $(libs) -lpthread
 
 ######################################################################
 

--- a/test/class/Makefile.am
+++ b/test/class/Makefile.am
@@ -92,13 +92,15 @@ ompi_rb_tree_DEPENDENCIES = $(ompi_rb_tree_LDADD)
 opal_lifo_SOURCES = opal_lifo.c
 opal_lifo_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
-	$(top_builddir)/test/support/libsupport.a
+	$(top_builddir)/test/support/libsupport.a \
+        -lpthread
 opal_lifo_DEPENDENCIES = $(opal_lifo_LDADD)
 
 opal_fifo_SOURCES = opal_fifo.c
 opal_fifo_LDADD = \
         $(top_builddir)/opal/lib@OPAL_LIB_PREFIX@open-pal.la \
-	$(top_builddir)/test/support/libsupport.a
+	$(top_builddir)/test/support/libsupport.a \
+        -lpthread
 opal_fifo_DEPENDENCIES = $(opal_fifo_LDADD)
 
 clean-local:

--- a/test/class/opal_fifo.c
+++ b/test/class/opal_fifo.c
@@ -18,6 +18,7 @@
 #include "opal/runtime/opal.h"
 #include "opal/constants.h"
 
+#include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>

--- a/test/class/opal_lifo.c
+++ b/test/class/opal_lifo.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <pthread.h>
 
 #include <sys/time.h>
 


### PR DESCRIPTION
It works in the following environment (MPICH's Argobots example (`ult_send_recv.c`))
- OpenMPI libraries with `--with-threads=argobots` with and without `--enable-debug`.
- OpenMPI-master Pthreads-version `mpiexec`
- OpenMPI-master Pthreads-version `mpicc`
- Argobots

It can run OSU benchmarks as well, but it is extremely slow (10~100x, need to be extremely patient)
To test on my laptop (Ubuntu 16.04 LTS), I need to pass `--mca-btl self,tcp` to `mpiexec`; otherwise, it hangs.

Pthreads version also works (`make check` and a few OSU benchmarks as far as I tested).
- OpenMPI libraries and binraries with `--with-threads=pthreads` without `--enable-debug`.

All the update should be included in #4, but to run `make check`, you might need to modify `test/*/Makefile.am`.

We need some features in the future:
```
- opal_yield()
- opal_usleep()
- mca_close_component() for a threading library (there's no way to finish a threading library)
- preprocessor for ULT to control msecs of (e)poll()
```
